### PR TITLE
You missed some fixes in your previous fix

### DIFF
--- a/Humble Trove Console Downloader/Program.vb
+++ b/Humble Trove Console Downloader/Program.vb
@@ -29,7 +29,7 @@ Module Program
     Public time = New Integer
     Public timethread As New Thread(AddressOf ThreadedTimer)
     Public abort_thread = False
-    Public seperator = ""
+    Public seperator = "/"
 
     Sub Main(args As String())
         If args.Length = 0 Then
@@ -64,14 +64,11 @@ Module Program
 
         If RuntimeInformation.IsOSPlatform(OSPlatform.Windows) Then
             seperator = "\"
-        Else
-            seperator = "/"
         End If
 
         Console.WriteLine($"Download: {download_type}")
         Console.WriteLine($"Platform: {platform}")
         Console.WriteLine($"Saving To: {save_to}")
-        Console.WriteLine($"Slash: {seperator}")
 
         Console.WriteLine("Fetching chunks, please wait...")
         timethread.Start()
@@ -118,7 +115,7 @@ Module Program
                     Console.WriteLine($"There are {win_links} files for me to download")
                     Console.WriteLine($"Creating directory {save_to}{seperator}Windows")
                 End If
-                Directory.CreateDirectory(save_to & "\Windows")
+                Directory.CreateDirectory(save_to & $"{seperator}Windows")
                 For Each link In win_downloads
                     downloaded += 1
                     Dim qs = New Uri(link).Query
@@ -135,7 +132,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Windows\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Windows{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {win_links} files, {win_links - downloaded} files left")
@@ -151,7 +148,7 @@ Module Program
                     Console.WriteLine($"There are {mac_links} files for me to download")
                     Console.WriteLine($"Creating directory {save_to}{seperator}Mac")
                 End If
-                Directory.CreateDirectory(save_to & "\Mac")
+                Directory.CreateDirectory(save_to & $"{seperator}Mac")
                 For Each link In mac_downloads
                     downloaded += 1
                     Dim qs = New Uri(link).Query
@@ -168,7 +165,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Mac\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Mac{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {mac_links} files, {mac_links - downloaded} files left")
@@ -184,7 +181,7 @@ Module Program
                     Console.WriteLine($"There are {lin_links} files for me to download")
                     Console.WriteLine($"Creating directory {save_to}{seperator}Linux")
                 End If
-                Directory.CreateDirectory(save_to & "\Linux")
+                Directory.CreateDirectory(save_to & $"{seperator}Linux")
                 For Each link In lin_downloads
                     downloaded += 1
                     Dim qs = New Uri(link).Query
@@ -201,7 +198,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Linux\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Linux{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {lin_links} files, {lin_links - downloaded} files left")
@@ -219,9 +216,9 @@ Module Program
                     Console.WriteLine($"Creating directory {save_to}{seperator}Mac")
                     Console.WriteLine($"Creating directory {save_to}{seperator}Linux")
                 End If
-                Directory.CreateDirectory(save_to & "\Windows")
-                Directory.CreateDirectory(save_to & "\Mac")
-                Directory.CreateDirectory(save_to & "\Linux")
+                Directory.CreateDirectory(save_to & $"{seperator}Windows")
+                Directory.CreateDirectory(save_to & $"{seperator}Mac")
+                Directory.CreateDirectory(save_to & $"{seperator}Linux")
                 For Each link In win_downloads
                     downloaded += 1
                     Dim qs = New Uri(link).Query
@@ -238,7 +235,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Windows\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Windows{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {all_links} files, {all_links - downloaded} files left")
@@ -259,7 +256,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Mac\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Mac{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {all_links} files, {all_links - downloaded} files left")
@@ -280,7 +277,7 @@ Module Program
                         Continue For
                     End If
                     Dim this_filename = Path.GetFileName(New Uri(this_dl).LocalPath)
-                    Dim this_filepath = $"{save_to}{seperator}Linux\{this_filename}"
+                    Dim this_filepath = $"{save_to}{seperator}Linux{seperator}{this_filename}"
                     GetFileURL(this_dl, this_filepath).Wait()
                     Console.SetCursorPosition(0, Console.CursorTop - 1)
                     Console.WriteLine($"I've downloaded {downloaded} / {all_links} files, {all_links - downloaded} files left")


### PR DESCRIPTION
I also optimised the seperator change by defaulting the variable to a forward slash and only changing it to a backslash if the platform is Windows (see: lines 32, 67 & 68)